### PR TITLE
Fixed typo in tern-org.ttl

### DIFF
--- a/docs/tern-org.ttl
+++ b/docs/tern-org.ttl
@@ -566,6 +566,6 @@ tern-org:orcID
 .
 <https://w3id.org/tern/resources/a083902d-d821-41be-b663-1d7cb33eea66>
   schema:alternateName "TERN" ;
-  schema:name "Terrestrial Ecoystem Research Network" ;
+  schema:name "Terrestrial Ecosystem Research Network" ;
   schema:url <https://www.tern.org.au/> ;
 .


### PR DESCRIPTION
There is a typo in TERN's name, `Ecoystem` should be `Ecosystem`.